### PR TITLE
fix: upgrade node and caddy for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Docker build environment #
 ############################
 
-FROM node:18.16.1-bookworm-slim AS build
+FROM node:18.20.4-bookworm-slim AS build
 
 # Upgrade all packages and install dependencies
 RUN apt-get update \
@@ -23,7 +23,7 @@ RUN npm i && npm run build
 # Docker final environment #
 ############################
 
-FROM caddy:2.7.4-alpine
+FROM caddy:2.8.4-alpine
 
 EXPOSE 80
 WORKDIR /var/www/html


### PR DESCRIPTION
Fix docker build related with node version:

```
12.04 
12.04 > public-pool-ui@0.0.0 build
12.04 > ng build --configuration=production && gzipper compress --gzip --brotli ./dist/public-pool-ui/
12.04 
12.06 Node.js version v18.16.1 detected.
12.06 The Angular CLI requires a minimum Node.js version of v18.19.
12.06 
12.06 Please update your Node.js version or visit https://nodejs.org/ for additional instructions.
12.06 
------
Dockerfile:20
--------------------
  18 |     
  19 |     # Build Public Pool UI using NPM
  20 | >>> RUN npm i && npm run build
  21 |     
  22 |     ############################
--------------------
ERROR: failed to solve: process "/bin/sh -c npm i && npm run build" did not complete successfully: exit code: 3
```