### PR TITLE
don't say 'ago' if it's 'just now'

### DIFF
--- a/src/app/components/splash/splash.component.html
+++ b/src/app/components/splash/splash.component.html
@@ -65,7 +65,7 @@
                 <div class="text-center mb-2">Uptime: {{uptime$ | async | dateAgo}}</div>
 
                 <ng-container *ngIf="chartData$ | async as chartData; else loadingChart">
-                    
+
                     <p-chart [responsive]="true" type="line" [data]="chartData" [options]="chartOptions"></p-chart>
 
                 </ng-container>
@@ -153,7 +153,7 @@
                                 <td><app-user-agent-link
                                         [userAgent]="highScore.bestDifficultyUserAgent ? highScore.bestDifficultyUserAgent : 'unknown'"></app-user-agent-link>
                                 </td>
-                                <td>{{ highScore.updatedAt | dateAgo}} ago</td>
+                                <td>{{ highScore.updatedAt | dateAgo}}</td>
                             </tr>
                         </ng-template>
                     </p-table>

--- a/src/app/pipes/date-ago.pipe.ts
+++ b/src/app/pipes/date-ago.pipe.ts
@@ -24,9 +24,9 @@ export class DateAgoPipe implements PipeTransform {
       for (const i in intervals) {
         const number = (seconds / intervals[i]).toFixed(1);
         counter = Math.floor(seconds / intervals[i]);
-        
+
         if (counter > 0)
-          return number + ' ' + i + 's'; // plural (2 days ago)
+          return number + ' ' + i + 's ago'; // plural (2 days ago)
           // if (counter === 1) {
           //   return number + ' ' + i + ''; // singular (1 day ago)
           // } else {


### PR DESCRIPTION
Problem: The dashboard says "Just now ago" which isn't grammatically correct
Solution: Only say "ago" if dateAgo comes up with units e.g. "2 hours"