### PR TITLE
Remove unused Chart.js

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -36,10 +36,7 @@
               "includePaths": [
                 "src/styles"
               ]
-            },
-            "scripts": [
-              "node_modules/chart.js/dist/chart.js"
-            ]
+            }
           },
           "configurations": {
             "electron": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@angular/platform-browser-dynamic": "18.1.0",
         "@angular/router": "18.1.0",
         "bitcoin-address-validation": "^2.2.3",
-        "chart.js": "^4.4.3",
         "chartjs-adapter-moment": "^1.0.1",
         "moment": "^2.30.1",
         "ng-particles": "^3.12.0",
@@ -3257,7 +3256,8 @@
     "node_modules/@kurkle/color": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
+      "peer": true
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -5316,6 +5316,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.3.tgz",
       "integrity": "sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@angular/platform-browser-dynamic": "18.1.0",
     "@angular/router": "18.1.0",
     "bitcoin-address-validation": "^2.2.3",
-    "chart.js": "^4.4.3",
     "chartjs-adapter-moment": "^1.0.1",
     "moment": "^2.30.1",
     "ng-particles": "^3.12.0",


### PR DESCRIPTION
A JS syntax error is shown in the browser JS console:

"Uncaught SyntaxError: Cannot use import statement outside a module"

(mentioned in https://github.com/benjamin-wilson/public-pool-ui/issues/29)

It is caused by Chart.js dependency, which seems to not be used anywhere in the code. After removing, everything is working fine, the error is gone.